### PR TITLE
Force to initialize the gripper when in the reset state.

### DIFF
--- a/robotiq_2f_gripper_action_server/include/robotiq_2f_gripper_action_server/robotiq_2f_gripper_action_server.h
+++ b/robotiq_2f_gripper_action_server/include/robotiq_2f_gripper_action_server/robotiq_2f_gripper_action_server.h
@@ -61,6 +61,7 @@ public:
 
 private:
   void issueActivation();
+  void issueReset();
 
   ros::NodeHandle nh_;
   actionlib::SimpleActionServer<control_msgs::GripperCommandAction> as_;

--- a/robotiq_2f_gripper_action_server/src/robotiq_2f_gripper_action_server.cpp
+++ b/robotiq_2f_gripper_action_server/src/robotiq_2f_gripper_action_server.cpp
@@ -147,8 +147,16 @@ void Robotiq2FGripperActionServer::analysisCB(const GripperInput::ConstPtr& msg)
     // Check to see if the gripper is active or if it has been asked to be active
     if (current_reg_state_.gSTA == 0x0 && goal_reg_state_.rACT != 0x1)
     {
-      // If it hasn't been asked, active it
-      issueActivation();
+      if (current_reg_state_.gACT == 0x1)
+      {
+        ROS_WARN("%s is in reset state.", action_name_.c_str(), current_reg_state_.gACT);
+        issueReset();
+      }
+      else
+      {
+        // If it hasn't been asked, active it
+        issueActivation();
+      }
     }
 
     // Otherwise wait for the gripper to activate
@@ -189,7 +197,16 @@ void Robotiq2FGripperActionServer::issueActivation()
   ROS_INFO("Activating gripper for gripper action server: %s", action_name_.c_str());
   GripperOutput out;
   out.rACT = 0x1;
-  out.rGTO = 0x1;
+  // other params should be zero
+  goal_reg_state_ = out;
+  goal_pub_.publish(out);
+}
+
+void Robotiq2FGripperActionServer::issueReset()
+{
+  ROS_INFO("Resetting gripper for gripper action server: %s", action_name_.c_str());
+  GripperOutput out;
+  out.rACT = 0x0;
   // other params should be zero
   goal_reg_state_ = out;
   goal_pub_.publish(out);


### PR DESCRIPTION
when gSTA==0 and gACT==1, per spec, we should reset this gripper to clear the fault state.